### PR TITLE
Add placeholder parameter to ForceReply type

### DIFF
--- a/django_tgbot/types/forcereply.py
+++ b/django_tgbot/types/forcereply.py
@@ -6,6 +6,7 @@ from . import BasicType
 class ForceReply(BasicType):
     fields = {
         'force_reply': BasicType.bool_interpreter,
+        'input_field_placeholder': str,
         'selective': BasicType.bool_interpreter
     }
 
@@ -13,5 +14,5 @@ class ForceReply(BasicType):
         super(ForceReply, self).__init__(obj)
 
     @classmethod
-    def a(cls, force_reply: bool, selective: Optional[bool] = None):
+    def a(cls, force_reply: bool, input_field_placeholder: Optional[str] = None, selective: Optional[bool] = None):
         return super().a(**locals())


### PR DESCRIPTION
This pull request is about adding `input_field_placeholder` parameter to the `ForceReply` type according to [telegram bots api](https://core.telegram.org/bots/api#forcereply).